### PR TITLE
Discard master and slave jargon

### DIFF
--- a/src/phenoman-src-1.0rc/pheno_man/pheno_man.py
+++ b/src/phenoman-src-1.0rc/pheno_man/pheno_man.py
@@ -1253,7 +1253,7 @@ class CombinedDummyCoder:
 
     def R(self, rstr):
         ''' Run R command and parse the output '''
-        tc = Popen(["R", '--slave', '--vanilla'], stdin = PIPE, stdout = PIPE, stderr = PIPE)
+        tc = Popen(["R", '--subordinate', '--vanilla'], stdin = PIPE, stdout = PIPE, stderr = PIPE)
         out, error = tc.communicate(rstr.encode(sys.getdefaultencoding()))
         if (tc.returncode):
             raise ValueError(" (exception captured from R) \n{0}".format(error.decode(sys.getdefaultencoding())))

--- a/src/phenoman-src-1.0rc/pheno_man/str4r.py
+++ b/src/phenoman-src-1.0rc/pheno_man/str4r.py
@@ -164,7 +164,7 @@ def runR(maer):
 		warnings = None
 		if not isinstance(maer, basestring):
 			raise ValueError("Input script must be a string")
-		tc = Popen(["R", '--slave', '--vanilla'], stdin = PIPE, stdout = PIPE, stderr = PIPE)
+		tc = Popen(["R", '--subordinate', '--vanilla'], stdin = PIPE, stdout = PIPE, stderr = PIPE)
 		out, error = tc.communicate(maer.encode(sys.getdefaultencoding()))
 		if (tc.returncode):
 			raise ValueError("**** R ERROR ****\n{}*****************\n".format(error.decode(sys.getdefaultencoding())))


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.